### PR TITLE
docs: improve query documentation and fix script redundancy

### DIFF
--- a/goldens.sh
+++ b/goldens.sh
@@ -1,13 +1,3 @@
-#!/bin/bash
-set -euxo pipefail
-
-cd "$(dirname "${BASH_SOURCE[0]}")"
-for test_file in test_files/*; do
-    test_file="$(basename "$test_file")"
-    echo "$test_file"
-    ./parse -file "test_files/$test_file" -use_tags_query -tags_query_dir "queries" > "goldens/$test_file.golden"
-done
-
 # Additional test cases to verify the improved queries
 ./parse -file "test_files/test.c" -use_tags_query -tags_query_dir "queries" > "goldens/test.c.golden"
 ./parse -file "test_files/test.cpp" -use_tags_query -tags_query_dir "queries" > "goldens/test.cpp.golden"

--- a/goldens.sh
+++ b/goldens.sh
@@ -1,8 +1,11 @@
-# Additional test cases to verify the improved queries
-./parse -file "test_files/test.c" -use_tags_query -tags_query_dir "queries" > "goldens/test.c.golden"
-./parse -file "test_files/test.cpp" -use_tags_query -tags_query_dir "queries" > "goldens/test.cpp.golden"
-./parse -file "test_files/test.cs" -use_tags_query -tags_query_dir "queries" > "goldens/test.cs.golden"
-./parse -file "test_files/test.dart" -use_tags_query -tags_query_dir "queries" > "goldens/test.dart.golden"
-./parse -file "test_files/test.go" -use_tags_query -tags_query_dir "queries" > "goldens/test.go.golden"
-./parse -file "test_files/test.java" -use_tags_query -tags_query_dir "queries" > "goldens/test.java.golden"
-./parse -file "test_files/test.js" -use_tags_query -tags_query_dir "queries" > "goldens/test.js.golden"
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# Generate golden test files for all test cases
+for test_file in test_files/*; do
+    test_file="$(basename "$test_file")"
+    echo "$test_file"
+    ./parse -file "test_files/$test_file" -use_tags_query -tags_query_dir "queries" > "goldens/$test_file.golden"
+done

--- a/queries/go_class_fields.scm
+++ b/queries/go_class_fields.scm
@@ -1,3 +1,4 @@
+;; Captures field declarations in Go struct types
 (type_declaration
     (type_spec
         type: (struct_type

--- a/queries/java_class_fields.scm
+++ b/queries/java_class_fields.scm
@@ -1,8 +1,11 @@
+;; Captures field declarations in Java classes
 (class_declaration
     (class_body
         (field_declaration) @field
     )
 )
+
+;; Captures constructor declarations in Java classes
 (class_declaration
     (class_body
         ([
@@ -11,11 +14,14 @@
     )
 )
 
+;; Captures field declarations in Java records (as parameters)
 (record_declaration
     (formal_parameters
         (formal_parameter) @field
     )
 )
+
+;; Captures constructor declarations in Java records
 (record_declaration
     (class_body
         ([

--- a/queries/ruby_tags.scm
+++ b/queries/ruby_tags.scm
@@ -1,4 +1,4 @@
-; Method definitions
+;; Method definitions
 
 (
   (comment)* @doc


### PR DESCRIPTION
- Add comprehensive documentation comments to go_class_fields.scm
- Add detailed documentation to java_class_fields.scm for both classes and records
- Standardize comment format in ruby_tags.scm from ';' to ';;'
- Remove redundant test execution code from goldens.sh script
- Enhance overall code documentation quality

## Summary by Sourcery

Improve documentation for query scripts and remove redundant code from the golden file generation script

Documentation:
- Add documentation comments to go_class_fields.scm
- Add detailed documentation for classes and records in java_class_fields.scm
- Standardize comment format to ';;' in ruby_tags.scm

Tests:
- Remove redundant test execution loop from goldens.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Go analysis now extracts struct field declarations.
  * Java analysis now captures both class/record fields and constructors.

* **Chores**
  * Minor formatting tweak to query comments.
  * Streamlined test golden-file generation workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->